### PR TITLE
Customize cert dir name, multiple keypairs

### DIFF
--- a/src/Commands/Issue.php
+++ b/src/Commands/Issue.php
@@ -114,7 +114,7 @@ class Issue implements Command {
             }
         }
 
-        $path = __DIR__ . "/../../data/live/" . reset($domains);
+        $path = __DIR__ . "/../../data/live/" . $args->get("file") ?? current($domains);
 
         if (!file_exists($path) && !mkdir($path, 0700, true)) {
             throw new AcmeException("Couldn't create directory: {$path}");
@@ -248,6 +248,12 @@ class Issue implements Command {
                 "description" => "Path to the document root for ACME challenges.",
                 "required" => false,
             ],
+            "file" => [
+                "prefix" => "f",
+                "longPrefix" => "file",
+                "descript" => "Output filename",
+                "required" => false,
+            ]
         ];
     }
 }

--- a/src/Commands/Register.php
+++ b/src/Commands/Register.php
@@ -62,8 +62,7 @@ class Register implements Command {
             $this->logger->info("Generating key keys ...");
 
             $keyPair = (new OpenSSLKeyGenerator)->generate(4096);
-
-            if (!mkdir($path, 0700, true)) {
+            if (!file_exists($path) && !mkdir($path, 0700, true)) {
                 throw new AcmeException("Couldn't create account directory");
             }
 


### PR DESCRIPTION
Add support for -f|--file to designate a different directory name for the certificate other than the common name
Permit multiple keypair creation (LE staging/production)
