### PR TITLE
Syntax fix (return/yield)

### DIFF
--- a/src/Stores/CertificateStore.php
+++ b/src/Stores/CertificateStore.php
@@ -26,7 +26,7 @@ class CertificateStore {
         Assert::string($name, "Name must be a string. Got: %s");
 
         try {
-            return yield \Amp\File\get($this->root . "/" . $name . "/cert.pem");
+            yield \Amp\File\get($this->root . "/" . $name . "/cert.pem");
         } catch (FilesystemException $e) {
             throw new CertificateStoreException("Failed to load certificate.", 0, $e);
         }


### PR DESCRIPTION
This fixes the following error on "issue" command:
`PHP Parse error:  syntax error, unexpected 'Amp' (T_STRING) in /root/acme-client/src/Stores/CertificateStore.php on line 29
`
