### PR TITLE
Add support for IPv6-only host names

### DIFF
--- a/src/Commands/Issue.php
+++ b/src/Commands/Issue.php
@@ -183,7 +183,7 @@ class Issue implements Command {
 
             foreach ($domainChunk as $domain) {
                 $promises[$domain] = \Amp\Dns\resolve($domain, [
-                    "types" => [Record::A],
+                    "types" => [Record::A, Record::AAAA],
                     "hosts" => false,
                 ]);
             }
@@ -194,7 +194,7 @@ class Issue implements Command {
         }
 
         if (!empty($errors)) {
-            throw new AcmeException("Couldn't resolve the following domains to an IPv4 record: " . implode(", ", array_keys($errors)));
+            throw new AcmeException("Couldn't resolve the following domains to an IPv4 nor IPv6 record: " . implode(", ", array_keys($errors)));
         }
     }
 


### PR DESCRIPTION
Let's Encrypt recently enabled support for IPv6-only host names (with no A record). This PR allows such host names to pass the DNS sanity check in checkDnsRecords().

See https://letsencrypt.org/2016/07/26/full-ipv6-support.html
