### PR TITLE
POSIX compliant cron example

### DIFF
--- a/doc/usage.md
+++ b/doc/usage.md
@@ -77,9 +77,10 @@ the script will be quiet to be cron friendly. If an error occurs, the script wil
 You should execute `acme-client auto` as a daily cron. It's recommended to setup e-mail notifications for all output of
 that script.
 
-```bash
-0 0 * * * acme-client auto; exit=$?; if [[ $exit = 4 ]] || [[ $exit = 5 ]]; then service nginx reload; fi
+```sh
+0 0 * * * /usr/local/sbin/acme-client auto; RC=$?; if [[ $RC = 4 ]] || [[ $RC = 5 ]]; then /usr/sbin/service nginx reload; fi
 ```
+The path to `acme-client` should be modified to suit your system. The full path should be used as the system path may not be set up in your cron environment.
 
 | Exit Code | Description |
 |-----------|-------------|


### PR DESCRIPTION
For #39 
Changed the cron auto example to be POSIX compliant and use full paths.
Changed `exit` variable to `RC` (commonly used in system scripts for "return code") as `exit` is a shell builtin.
Added note about setting the full path as $PATH may not be set.
