### PR TITLE
fix config example

### DIFF
--- a/doc/usage.md
+++ b/doc/usage.md
@@ -54,13 +54,13 @@ certificates:
     #        but some servers might require to be owner of files they serve.
     #
     - bits: 4096
-      paths:
+    - paths:
         /var/www/example:
             - example.org
             - www.example.org
     # You can have multiple certificate with different users and key options.
     - user: www-data
-      paths:
+    - paths:
         /var/www: example.org
 ```
 


### PR DESCRIPTION
Without this notation script thtown error

$ certbot auto
TypeError: Argument 1 passed to Kelunik\AcmeClient\Commands\Auto::toDomainPathMap() must be of the type array, null given, called in /usr/home/czat/acme-client/src/Commands/Auto.php on line 181 and defined in /usr/home/czat/acme-client/src/Commands/Auto.php:257