### PR TITLE
Fix issuance of reordered domain names

### DIFF
--- a/src/Commands/Issue.php
+++ b/src/Commands/Issue.php
@@ -143,7 +143,7 @@ class Issue implements Command
             [$errors] = yield AcmeClient\concurrentMap(
                 $concurrency,
                 $order->getAuthorizationUrls(),
-                function ($authorizationUrl, $i) use ($acme, $key, $domains, $docRoots, $user) {
+                function ($authorizationUrl) use ($acme, $key, $domains, $docRoots, $user) {
                     /** @var Authorization $authorization */
                     $authorization = yield $acme->getAuthorization($authorizationUrl);
 
@@ -161,7 +161,7 @@ class Issue implements Command
                         throw new AcmeException('Unknown identifier returned: ' . $name);
                     }
 
-                    return yield from $this->solveChallenge($acme, $key, $authorization, $domains[$i], $docRoots[$i],
+                    return yield from $this->solveChallenge($acme, $key, $authorization, $name, $docRoots[$index],
                         $user);
                 }
             );


### PR DESCRIPTION
Letsencrypt seems to reorder domain names alphabetically - acme currently puts the well_known file into the wrong path.